### PR TITLE
gatt: terminate strings at \0

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -1,6 +1,7 @@
 package gatt
 
 import (
+	"bytes"
 	"errors"
 )
 
@@ -122,9 +123,9 @@ func (a *Advertisement) unmarshall(b []byte) error {
 		case typeAllUUID128:
 			a.Services = uuidList(a.Services, d, 16)
 		case typeShortName:
-			a.LocalName = string(d)
+			a.LocalName = zeroTruncate(d)
 		case typeCompleteName:
-			a.LocalName = string(d)
+			a.LocalName = zeroTruncate(d)
 		case typeTxPower:
 			a.TxPowerLevel = int(d[0])
 		case typeServiceSol16:
@@ -147,6 +148,14 @@ func (a *Advertisement) unmarshall(b []byte) error {
 		b = b[1+l:]
 	}
 	return nil
+}
+
+func zeroTruncate(b []byte) string {
+	i := bytes.Index(b, []byte{0})
+	if i < 0 {
+		return string(b)
+	}
+	return string(b[:i])
 }
 
 // AdvPacket is an utility to help crafting advertisment or scan response data.

--- a/adv.go
+++ b/adv.go
@@ -89,9 +89,9 @@ func (a *Advertisement) unmarshall(b []byte) error {
 	}
 
 	serviceDataList := func(sd []ServiceData, d []byte, w int) []ServiceData {
-		serviceData := ServiceData {UUID{d[:w]}, make([]byte, len(d) - w)}
-                copy(serviceData.Data, d[2:])
-                return append(sd, serviceData)
+		serviceData := ServiceData{UUID{d[:w]}, make([]byte, len(d)-w)}
+		copy(serviceData.Data, d[2:])
+		return append(sd, serviceData)
 	}
 
 	for len(b) > 0 {


### PR DESCRIPTION
It seems that sometimes we're lied to about the length. For example on this device
```
[13:34:26] [ble.device.new] New BLE device HMSoft detected as 5C:F8:21:90:1E:4F (Texas Instruments) -43 dBm.
```
what the `LocalName` is is `[]byte{0x48, 0x4d, 0x53, 0x6f, 0x66, 0x74, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}`. This screws up formatting and various other things that people might want to do in a fairly invisible way.