### PR TITLE
Translating string descriptor vals to []bytes in MustGetBytes()

### DIFF
--- a/xpc/xpc_darwin.go
+++ b/xpc/xpc_darwin.go
@@ -44,7 +44,14 @@ func (d Dict) MustGetArray(k string) Array {
 }
 
 func (d Dict) MustGetBytes(k string) []byte {
-	return d[k].([]byte)
+	switch t := d[k].(type) {
+	case string:
+		return []byte(d[k].(string))
+	case []byte:
+		return d[k].([]byte)
+	default:
+		panic(fmt.Sprintf("unknown type %v", t))
+	}
 }
 
 func (d Dict) MustGetHexBytes(k string) string {


### PR DESCRIPTION
This was panicking when accessing the descriptor for a peripheral Battery Service. Pls. accept or reject as you see fit!