### PR TITLE
Fix closing device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/bettercap/gatt
+
+go 1.13
+
+require (
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab
+	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
+github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab h1:n8cgpHzJ5+EDyDri2s/GC7a9+qK3/YEGnBsd0uS/8PY=
+github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab/go.mod h1:y1pL58r5z2VvAjeG1VLGc8zOQgSOzbKN7kMHPvFXJ+8=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
+golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/linux/hci.go
+++ b/linux/hci.go
@@ -195,13 +195,10 @@ func (h *HCI) mainLoop() {
 			log.Printf("mainloop err: %v", err)
 			return
 		}
-		if n == 0 {
-			log.Printf("mainLoop failed to read")
-			return
+		if n > 0 {
+			// log.Printf("hci.mainLoop -> handlePacket")
+			h.handlePacket(b, n)
 		}
-
-		// log.Printf("hci.mainLoop -> handlePacket")
-		h.handlePacket(b, n)
 	}
 	log.Printf("hci.mainLoop stopped")
 }

--- a/linux/hci.go
+++ b/linux/hci.go
@@ -92,7 +92,7 @@ func NewHCI(devID int, chk bool, maxConn int) (*HCI, error) {
 
 func (h *HCI) Close() error {
 	log.Printf("hci.Close()")
-	h.pool.Put(nil)
+	h.pool.Close()
 	<-h.loopDone
 	log.Printf("mainLoop exited")
 	for _, c := range h.conns {

--- a/linux/util/pool.go
+++ b/linux/util/pool.go
@@ -12,6 +12,10 @@ func NewBytePool(width int, depth int) *BytePool {
 	}
 }
 
+func (p *BytePool) Close() {
+	close(p.pool)
+}
+
 func (p *BytePool) Get() (b []byte) {
 	select {
 	case b = <-p.pool:


### PR DESCRIPTION
These changes allow to use the gatt device.Stop() method for "properly" stopping and closing resources (mainly the unix socket).
Before: the hci loop would get stuck on reading from the device.
After: the reading to the device is using poll before reading; the hci loops does not break when nothing is read.