### PR TITLE
Fix concurrency bug: when unmarshalling an aclData packet, we need to copy the data buffer.

### DIFF
--- a/linux/l2cap.go
+++ b/linux/l2cap.go
@@ -26,7 +26,10 @@ func (a *aclData) unmarshal(b []byte) error {
 		return fmt.Errorf("malformed acl packet")
 	}
 
-	*a = aclData{attr: attr, flags: flags, dlen: dlen, b: b[4:]}
+	*a = aclData{attr: attr, flags: flags, dlen: dlen, b: make([]byte, dlen)}
+	if c := copy(a.b, b[4:]); c != int(dlen) {
+		return fmt.Errorf("expected to copy %d bytes, copied %d", dlen, c)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The bug that otherwise happens is:
1. HCI.mainLoop gets a byte buffer, reads into it, calls handlePacket
2. handlePacket calls handleL2CAP, which unmarshals into an aclData. This aclData references the original b slice
3. handleL2CAP adds the aclData to a channel
4. handlePacket returns the buffer to the pool
5. Repeat from 1, getting the same buffer _while the aclData referencing it is still in the channel_
Triggering this needs a relatively high data rate, but was possible repeatably for me with a Polar H10.